### PR TITLE
According to JMM there needs to be a happens-before relationship

### DIFF
--- a/src/main/scala/com/wix/async/AsyncExecution.scala
+++ b/src/main/scala/com/wix/async/AsyncExecution.scala
@@ -27,7 +27,7 @@ protected[async] class AsyncExecution[T](executorService: ExecutorService,
   def apply(blockingExecution: => T): Future[T] = execute(retryPolicy)(blockingExecution)
 
   protected lazy val pool = FuturePool(executorService)
-  private var started = false
+  @volatile private var started = false
   private def execute(retryPolicy: RetryPolicy)(blockingExecution: => T): Future[T] = {
     val submittedToQueue = Stopwatch.start()
 


### PR DESCRIPTION
between reads and writes of a variable in different threads
(ie: initial function execution thread and recover thread). I
haven't found any docs explaining what guarantees scala futures
provide, so I think it would be safer to have a volatile started
variable there.

/cc @electricmonk @pavelme 