### PR TITLE
bug fix: RetrySupport ignores the delay strategy provided with RetryP…

### DIFF
--- a/src/main/scala/com/wix/async/RetrySupport.scala
+++ b/src/main/scala/com/wix/async/RetrySupport.scala
@@ -1,6 +1,6 @@
 package com.wix.async
 
-import DelayStrategy._
+import com.wix.async.DelayStrategy._
 
 /**
  * User: avitaln
@@ -12,7 +12,9 @@ trait RetrySupport {
     try {
       fn
     } catch {
-      case e : Throwable if retryPolicy.shouldRetryFor(e) => withRetry(retryPolicy.next)(fn)
+      case e : Throwable if retryPolicy.shouldRetryFor(e) =>
+        retryPolicy.delayStrategy.delay()
+        withRetry(retryPolicy.next)(fn)
     }
   }
 }

--- a/src/test/scala/com/wix/async/RetrySupportTest.scala
+++ b/src/test/scala/com/wix/async/RetrySupportTest.scala
@@ -1,23 +1,33 @@
 package com.wix.async
 
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.mock.Mockito
-import org.specs2.specification.Scope
 import org.mockito.Mockito._
+import org.specs2.mock.Mockito
+import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.specification.Scope
+import org.specs2.time.NoTimeConversions
+
+import scala.compat.Platform
+import scala.concurrent.duration._
 
 
 /**
  * User: avitaln
  * Date: 9/30/13
  */
-class RetrySupportTest extends SpecificationWithJUnit with Mockito {
+class RetrySupportTest extends SpecificationWithJUnit with Mockito with NoTimeConversions {
 
   trait Dummy {
     def func() : Int
+    def elapsedFromSpecStart(): Duration
   }
 
   trait Context extends Scope with RetrySupport {
     val dummy = mock[Dummy]
+    val startTime = Platform.currentTime
+    val elapsedTimeAnswer = new MockAnswer[Duration]({ _ => elapsedUntilNow })
+    val retryDelay: Duration = 200.millis
+
+    def elapsedUntilNow = (Platform.currentTime - startTime).millis
   }
 
   "withRetry" should {
@@ -31,6 +41,27 @@ class RetrySupportTest extends SpecificationWithJUnit with Mockito {
       result must_== 88
 
       there were two(dummy).func()
+    }
+
+    "delay retries according to the specified delay strategy" in new Context {
+      when(dummy.elapsedFromSpecStart())
+        .thenThrow(new IllegalArgumentException)
+        .thenAnswer(elapsedTimeAnswer)
+
+      val retryPolicyWithDelay = onceFor[IllegalArgumentException].copy(
+        delayStrategy = DelayStrategy.constant(retryDelay)
+      )
+
+      val elapsedUntilSecondRetry = withRetry(retryPolicyWithDelay) {
+        dummy.elapsedFromSpecStart()
+      }
+
+      elapsedUntilSecondRetry must {
+        beGreaterThanOrEqualTo(retryDelay) and
+        beLessThanOrEqualTo(elapsedUntilNow)
+      }
+
+      there were two(dummy).elapsedFromSpecStart()
     }
 
     "not retry on another exception" in new Context {


### PR DESCRIPTION
@ittaiz (or anyone else) - as the commit message says, this fixes a bug in RetrySupport, which before this fix ignores the DelayStrategy specified as a part of the RetryPolicy. 

In addition to the bug fix, I would really like to make 'withRetry' a @tailrec, but in order to do that I have to make it 'final', which is a compatibility break - so if you think it's valid, I will happily do it.